### PR TITLE
Fix: Separate stop and delete functionality for agents

### DIFF
--- a/internal/coordinator/server.go
+++ b/internal/coordinator/server.go
@@ -445,6 +445,13 @@ func (s *Server) handleSpaceRoute(w http.ResponseWriter, r *http.Request) {
 		} else {
 			http.Error(w, "agent name required", http.StatusBadRequest)
 		}
+	case "stop":
+		if len(parts) == 3 {
+			agentName := strings.TrimRight(parts[2], "/")
+			s.handleStopAgent(w, r, spaceName, agentName)
+		} else {
+			http.Error(w, "agent name required", http.StatusBadRequest)
+		}
 	case "delete":
 		if len(parts) == 3 {
 			agentName := strings.TrimRight(parts[2], "/")
@@ -1258,6 +1265,52 @@ func (s *Server) handleLaunchAgent(w http.ResponseWriter, r *http.Request, space
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"session_id": sessionID, "agent": canonical, "status": "launching"})
+}
+
+func (s *Server) handleStopAgent(w http.ResponseWriter, r *http.Request, spaceName, agentName string) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	ks, ok := s.getSpace(spaceName)
+	if !ok {
+		http.Error(w, fmt.Sprintf("space %q not found", spaceName), http.StatusNotFound)
+		return
+	}
+	s.mu.RLock()
+	canonical := resolveAgentName(ks, agentName)
+	agent, exists := ks.Agents[canonical]
+	var sessionID string
+	if exists {
+		sessionID = agent.ACPSessionID
+	}
+	s.mu.RUnlock()
+	if !exists {
+		http.Error(w, "agent not found: "+agentName, http.StatusNotFound)
+		return
+	}
+	if sessionID != "" && acpAvailable(s.acpConfig) {
+		if err := acpStopSession(s.acpConfig, sessionID); err != nil {
+			http.Error(w, "stop session: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	s.mu.Lock()
+	agent.Phase = "idle"
+	agent.UpdatedAt = time.Now().UTC()
+	ks.Agents[canonical] = agent
+	ks.UpdatedAt = time.Now().UTC()
+	if err := s.saveSpace(ks); err != nil {
+		s.mu.Unlock()
+		http.Error(w, fmt.Sprintf("save: %v", err), http.StatusInternalServerError)
+		return
+	}
+	s.mu.Unlock()
+	s.logEvent(fmt.Sprintf("[%s/%s] agent stopped: %s", spaceName, canonical, sessionID))
+	sseData, _ := json.Marshal(map[string]string{"space": spaceName, "agent": canonical})
+	s.broadcastSSE(spaceName, "agent_stopped", string(sseData))
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "stopped", "agent": canonical, "session_id": sessionID})
 }
 
 func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request, spaceName, agentName string) {

--- a/internal/coordinator/static/mission-control.html
+++ b/internal/coordinator/static/mission-control.html
@@ -428,6 +428,7 @@ header h1 span{color:var(--blue);font-weight:400;margin-left:6px;font-size:14px}
       <span id="agent-count"></span>
       <span id="last-update"></span>
       <button class="btn btn-primary btn-sm" onclick="showCreateSessionModal()" style="font-size:11px;padding:4px 12px">+ New Session</button>
+      <button id="stop-all-btn" class="btn btn-sm" onclick="stopAllAgents()" style="font-size:11px;padding:4px 12px;background:rgba(255,159,64,.08);border:1px solid rgba(255,159,64,.25);color:var(--orange);display:none">Stop All</button>
       <button id="delete-space-btn" class="btn btn-sm" onclick="showDeleteSpaceModal()" style="font-size:11px;padding:4px 12px;background:rgba(248,81,73,.08);border:1px solid rgba(248,81,73,.25);color:var(--red);display:none">Delete Space</button>
     </div>
   </div>
@@ -746,6 +747,25 @@ function updateDeleteSpaceBtn(agentCount){
   }
 }
 
+function updateStopAllBtn(data){
+  var btn = document.getElementById('stop-all-btn');
+  if (!btn) return;
+  if (!data || !data.agents) {
+    btn.style.display = 'none';
+    return;
+  }
+  var runningCount = Object.keys(data.agents).filter(function(name){
+    var agent = data.agents[name];
+    return agent && agent.phase === 'running';
+  }).length;
+  if (runningCount > 0) {
+    btn.style.display = '';
+    btn.title = 'Stop all ' + runningCount + ' running agent(s)';
+  } else {
+    btn.style.display = 'none';
+  }
+}
+
 function showDeleteSpaceModal(){
   if (!SPACE) return;
   closeLaunchModal();
@@ -921,7 +941,7 @@ function renderSessionTable(sessionData){
       h += '<tr>';
       h += '<td class="ov-poke" style="white-space:nowrap">';
       h += '<button class="btn-ov-poke" data-agent="' + esc(t.agent) + '" onclick="event.stopPropagation();pokeAgent(\'' + esc(t.agent).replace(/'/g,"\\'") + '\', this)" title="Check in ' + esc(t.agent) + '">&#x21bb;</button>';
-      if (isRunning) h += ' <button class="btn-ov-poke" style="color:var(--red);border-color:rgba(248,81,73,.3)" onclick="deleteAgent(event,\'' + esc(t.agent).replace(/'/g,"\\'") + '\')" title="Delete ' + esc(t.agent) + '">&#x25A0;</button>';
+      if (isRunning) h += ' <button class="btn-ov-poke" style="color:var(--orange);border-color:rgba(255,159,64,.3)" onclick="stopAgent(event,\'' + esc(t.agent).replace(/'/g,"\\'") + '\')" title="Stop ' + esc(t.agent) + '">&#x25A0;</button>';
       h += '</td>';
       h += '<td style="color:#fff;font-weight:600">' + esc(t.agent) + '</td>';
       h += '<td><span class="session-dot ' + dotCls + '"></span>' + esc(phase) + '</td>';
@@ -955,6 +975,81 @@ function toggleAgentMenu(e, btn){
   if (!wasOpen) menu.classList.add('open');
 }
 document.addEventListener('click', function(){ document.querySelectorAll('.agent-menu.open').forEach(function(m){ m.classList.remove('open'); }); });
+
+function stopAgent(e, agentName){
+  e.stopPropagation();
+  document.querySelectorAll('.agent-menu.open').forEach(function(m){ m.classList.remove('open'); });
+  closeLaunchModal();
+  var overlay = document.createElement('div');
+  overlay.id = 'launch-modal-overlay';
+  overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:200;display:flex;align-items:center;justify-content:center';
+  overlay.innerHTML = '<div style="background:var(--bg2);border:1px solid var(--border2);border-radius:12px;padding:24px;width:400px;max-width:90vw">'
+    + '<div style="font-size:14px;font-weight:700;color:#fff;margin-bottom:4px">Stop Agent</div>'
+    + '<div style="font-size:11px;color:var(--text2);margin-bottom:16px">Are you sure you want to stop <strong style="color:var(--orange)">' + esc(agentName) + '</strong>? This will stop its ACP session but keep the agent on the board.</div>'
+    + '<div style="display:flex;gap:8px;justify-content:flex-end">'
+    + '<button onclick="closeLaunchModal()" style="padding:7px 16px;background:var(--bg3);border:1px solid var(--border2);border-radius:6px;color:var(--text2);font-size:12px;cursor:pointer">Cancel</button>'
+    + '<button id="stop-confirm" style="padding:7px 16px;background:rgba(255,159,64,.12);border:1px solid rgba(255,159,64,.4);border-radius:6px;color:var(--orange);font-size:12px;font-weight:600;cursor:pointer">Stop</button>'
+    + '</div></div>';
+  document.body.appendChild(overlay);
+  launchModal = overlay;
+  overlay.addEventListener('click', function(ev){ if (ev.target === overlay) closeLaunchModal(); });
+  overlay.querySelector('#stop-confirm').onclick = function(){
+    closeLaunchModal();
+    broadcastLog.push({time: new Date().toLocaleTimeString(), cls:'log-info', msg:'Stopping ' + agentName + '...'});
+    renderBroadcastLog();
+    fetch('/spaces/' + encodeURIComponent(SPACE) + '/stop/' + encodeURIComponent(agentName), {method:'POST'}).then(function(r){
+      if (!r.ok) return r.text().then(function(t){ throw new Error(t); });
+      broadcastLog.push({time: new Date().toLocaleTimeString(), cls:'log-ok', msg:agentName + ' stopped'});
+      renderBroadcastLog();
+      setTimeout(function(){ loadSpace(SPACE); }, 500);
+    }).catch(function(err){
+      broadcastLog.push({time: new Date().toLocaleTimeString(), cls:'log-err', msg:agentName + ' stop failed: ' + err.message});
+      renderBroadcastLog();
+    });
+  };
+}
+
+function stopAllAgents(){
+  if (!cachedData || !cachedData.agents) return;
+  var runningAgents = Object.keys(cachedData.agents).filter(function(name){
+    var agent = cachedData.agents[name];
+    return agent && agent.phase === 'running';
+  });
+  if (runningAgents.length === 0) {
+    broadcastLog.push({time: new Date().toLocaleTimeString(), cls:'log-info', msg:'No running agents to stop'});
+    renderBroadcastLog();
+    return;
+  }
+  var overlay = document.createElement('div');
+  overlay.id = 'launch-modal-overlay';
+  overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:200;display:flex;align-items:center;justify-content:center';
+  overlay.innerHTML = '<div style="background:var(--bg2);border:1px solid var(--border2);border-radius:12px;padding:24px;width:400px;max-width:90vw">'
+    + '<div style="font-size:14px;font-weight:700;color:#fff;margin-bottom:4px">Stop All Agents</div>'
+    + '<div style="font-size:11px;color:var(--text2);margin-bottom:16px">Are you sure you want to stop all <strong style="color:var(--orange)">' + runningAgents.length + ' running agent(s)</strong>? This will stop their ACP sessions but keep them on the board.</div>'
+    + '<div style="display:flex;gap:8px;justify-content:flex-end">'
+    + '<button onclick="closeLaunchModal()" style="padding:7px 16px;background:var(--bg3);border:1px solid var(--border2);border-radius:6px;color:var(--text2);font-size:12px;cursor:pointer">Cancel</button>'
+    + '<button id="stop-all-confirm" style="padding:7px 16px;background:rgba(255,159,64,.12);border:1px solid rgba(255,159,64,.4);border-radius:6px;color:var(--orange);font-size:12px;font-weight:600;cursor:pointer">Stop All</button>'
+    + '</div></div>';
+  document.body.appendChild(overlay);
+  launchModal = overlay;
+  overlay.addEventListener('click', function(ev){ if (ev.target === overlay) closeLaunchModal(); });
+  overlay.querySelector('#stop-all-confirm').onclick = function(){
+    closeLaunchModal();
+    broadcastLog.push({time: new Date().toLocaleTimeString(), cls:'log-info', msg:'Stopping ' + runningAgents.length + ' agent(s)...'});
+    renderBroadcastLog();
+    var promises = runningAgents.map(function(agentName){
+      return fetch('/spaces/' + encodeURIComponent(SPACE) + '/stop/' + encodeURIComponent(agentName), {method:'POST'});
+    });
+    Promise.all(promises).then(function(){
+      broadcastLog.push({time: new Date().toLocaleTimeString(), cls:'log-ok', msg:'All agents stopped'});
+      renderBroadcastLog();
+      setTimeout(function(){ loadSpace(SPACE); }, 500);
+    }).catch(function(err){
+      broadcastLog.push({time: new Date().toLocaleTimeString(), cls:'log-err', msg:'Stop all failed: ' + err.message});
+      renderBroadcastLog();
+    });
+  };
+}
 
 function deleteAgent(e, agentName){
   e.stopPropagation();
@@ -1066,6 +1161,7 @@ function renderConsole(data, sessionData, eventLog){
   document.getElementById('agent-count').innerHTML = dot + names.length + ' agents';
   document.getElementById('last-update').textContent = 'Updated ' + new Date(data.updated_at).toLocaleString();
   updateDeleteSpaceBtn(names.length);
+  updateStopAllBtn(data);
 
   var logEl = document.getElementById('event-log');
   if (logEl) logEl.scrollTop = logEl.scrollHeight;
@@ -1140,6 +1236,7 @@ function renderBoard(data, sessionData, eventLog, interruptMetrics, interruptLog
   document.getElementById('agent-count').innerHTML = dot + names.length + ' agents';
   document.getElementById('last-update').textContent = 'Updated ' + new Date(data.updated_at).toLocaleString();
   updateDeleteSpaceBtn(names.length);
+  updateStopAllBtn(data);
   renderBroadcastLog();
 }
 
@@ -1164,7 +1261,7 @@ function renderPanelOverview(data, sorted, sessionData){
     o += '<td class="ov-poke" style="white-space:nowrap">';
     o += '<button class="btn-ov-poke" data-agent="' + esc(name) + '" onclick="event.stopPropagation();pokeAgent(\'' + esc(name).replace(/'/g,"\\'") + '\', this)" title="Check in ' + esc(name) + '">&#x21bb;</button>';
     if (phase !== 'running') o += ' <button class="btn-ov-poke" style="background:rgba(77,158,255,.06);border-color:rgba(77,158,255,.2);color:var(--blue)" onclick="event.stopPropagation();showLaunchModal(\'' + esc(name).replace(/'/g,"\\'") + '\')" title="Launch ' + esc(name) + '">&#x25BA;</button>';
-    if (phase === 'running') o += ' <button class="btn-ov-poke" style="color:var(--red);border-color:rgba(248,81,73,.3)" onclick="deleteAgent(event,\'' + esc(name).replace(/'/g,"\\'") + '\')" title="Delete ' + esc(name) + '">&#x25A0;</button>';
+    if (phase === 'running') o += ' <button class="btn-ov-poke" style="color:var(--orange);border-color:rgba(255,159,64,.3)" onclick="stopAgent(event,\'' + esc(name).replace(/'/g,"\\'") + '\')" title="Stop ' + esc(name) + '">&#x25A0;</button>';
     o += '</td>';
     o += '<td class="ov-name">' + esc(name) + '</td>';
     var ovStatus = a.status || 'idle';


### PR DESCRIPTION
Fixes the stop button bug where stopping an agent would delete it instead of just stopping the session.

## Backend Changes
- Add handleStopAgent endpoint at POST /spaces/{space}/stop/{agent}
- Use existing acpStopSession() to stop session without deleting
- Update agent phase to idle instead of removing from agents map
- Broadcast agent_stopped SSE event

## Frontend Changes
- Add stopAgent() function with confirmation modal
- Update stop button handlers to call stopAgent() instead of deleteAgent()
- Change stop button color from red to orange
- Change button title from Delete to Stop
- Add Stop All button in header toolbar
- Keep delete functionality in agent dropdown menu

## Testing
- All 43 existing tests pass with race detection
- Build successful
- No external dependencies added

Fixes #9