### PR TITLE
docs: add /edit/ endpoint to API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Spaces are independent coordination contexts. Each space is a KnowledgeSpace wit
 |--------|----------|-------------|
 | `GET` | `/spaces/{space}/agent/{name}` | Get agent state as JSON |
 | `POST` | `/spaces/{space}/agent/{name}` | Update agent (requires `X-Agent-Name` header) |
+| `POST` | `/spaces/{space}/edit/{agent}` | Edit agent task prompt and repository list |
 | `POST` | `/spaces/{space}/stop/{name}` | Stop agent's ACP session (agent remains on board) |
 | `DELETE` | `/spaces/{space}/agent/{name}` | Stop session AND remove agent from space |
 | `GET` | `/spaces/{space}/api/agents` | All agents as JSON map |


### PR DESCRIPTION
## Summary
- Documents the new `POST /spaces/{space}/edit/{agent}` endpoint added in PR #23 (Issue #19)
- Adds endpoint to the Agents API reference table in README.md

## Context
PR #23 introduced agent edit functionality allowing modification of task prompts and repository lists. This PR ensures the API reference documentation remains current.

## Changes
- Added `/edit/` endpoint row to README.md Agents API table

## Test plan
- [x] Verify endpoint documented correctly in README.md
- [x] Confirm follows existing API documentation format
- [x] No functional code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)