### PR TITLE
feat: Visualize Contracts in UI

### DIFF
--- a/internal/coordinator/static/mission-control.html
+++ b/internal/coordinator/static/mission-control.html
@@ -343,6 +343,19 @@ header h1 span{color:var(--blue);font-weight:400;margin-left:6px;font-size:14px}
 .archive-body{padding:16px;display:none;font-size:12px;color:var(--text2);line-height:1.7}
 .archive-body.open{display:block}
 
+.contracts-card{background:var(--bg2);border:1px solid var(--purple);border-radius:var(--radius);padding:0}
+.contracts-header{
+  padding:12px 16px;border-bottom:1px solid rgba(163,113,247,.2);
+  background:var(--purple-bg);display:flex;align-items:center;gap:12px;cursor:pointer;
+}
+.contracts-header:hover{background:rgba(163,113,247,.15)}
+.contracts-header .card-title{color:var(--purple);flex-shrink:0}
+.contracts-desc{font-size:11px;color:var(--text3);flex:1}
+.contracts-toggle{color:var(--text3);font-size:10px;transition:transform .2s;flex-shrink:0}
+.contracts-header:hover .contracts-toggle{color:var(--purple)}
+.contracts-body{padding:16px;display:none;font-size:12px;color:var(--text2);line-height:1.7;max-height:500px;overflow-y:auto}
+.contracts-body.open{display:block}
+
 .empty-state{text-align:center;padding:80px 28px;color:var(--text3)}
 .empty-state h2{color:var(--text2);font-size:18px;margin-bottom:8px}
 .empty-state p{font-size:13px;max-width:420px;margin:0 auto}
@@ -1298,6 +1311,7 @@ function ensureBoardSkeleton(){
   o += '<div id="panel-inbox"></div>';
   o += '<div id="panel-interrupts"></div>';
   o += '</div>';
+  o += '<div id="panel-contracts"></div>';
   o += '<div id="panel-agents"></div>';
   document.getElementById('page').innerHTML = o;
   boardSkeletonReady = true;
@@ -1318,6 +1332,7 @@ function renderBoard(data, sessionData, eventLog, interruptMetrics, interruptLog
   renderPanelOverview(data, sorted, sessionData);
   if (!inboxLocked) renderPanelInbox(data, sorted);
   renderPanelInterrupts(interruptMetrics, interruptLog);
+  renderPanelContracts(data);
   renderPanelAgents(data, sorted, sessionData);
 
   var dot = '<span class="header-dot" style="background:var(--green)"></span>';
@@ -1467,6 +1482,26 @@ function renderPanelInterrupts(interruptMetrics, interruptLog){
   }
   o += '</div></div>';
   document.getElementById('panel-interrupts').innerHTML = o;
+}
+
+function renderPanelContracts(data){
+  if (!data.shared_contracts || data.shared_contracts.trim() === '') {
+    document.getElementById('panel-contracts').innerHTML = '';
+    return;
+  }
+
+  var o = '';
+  o += '<div class="contracts-card" style="margin-bottom:20px">';
+  o += '<div class="contracts-header" onclick="this.nextElementSibling.classList.toggle(\'open\')">';
+  o += '<span class="card-title">Shared Contracts</span>';
+  o += '<span class="contracts-desc">Team agreements, conventions, and architectural decisions</span>';
+  o += '<span class="contracts-toggle">&#x25BC;</span>';
+  o += '</div>';
+  o += '<div class="contracts-body open">';
+  o += renderFreeText(data.shared_contracts);
+  o += '</div></div>';
+
+  document.getElementById('panel-contracts').innerHTML = o;
 }
 
 function renderPanelAgents(data, sorted, sessionData){


### PR DESCRIPTION
## Summary
- Added Shared Contracts section to mission control dashboard
- Contracts display between top metrics row and agents section
- Read-only visualization with collapsible panel
- Styled with purple theme to distinguish from other sections

## Implementation
- Created `renderPanelContracts()` function to render contracts
- Added `panel-contracts` div to page skeleton in `ensureBoardSkeleton()`
- Called `renderPanelContracts()` from `renderBoard()`
- Added CSS styling for contracts card, header, and body
- Uses `renderFreeText()` to display contracts with markdown formatting
- Collapsible panel with descriptive text explaining contract purpose

## Testing
- All 80 tests passing with race detection
- Build successful
- Ready for UI review

## Closes
Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)