### PR TITLE
fix: edit button modal not appearing (Issue #30)

### DIFF
--- a/internal/coordinator/static/mission-control.html
+++ b/internal/coordinator/static/mission-control.html
@@ -1101,10 +1101,10 @@ function editAgent(e, agentName){
 
   // Find current agent data to pre-fill form
   var agent = null;
-  if (SPACE_DATA && SPACE_DATA.agents) {
-    for (var name in SPACE_DATA.agents) {
+  if (cachedBoardData && cachedBoardData.agents) {
+    for (var name in cachedBoardData.agents) {
       if (name === agentName) {
-        agent = SPACE_DATA.agents[name];
+        agent = cachedBoardData.agents[name];
         break;
       }
     }


### PR DESCRIPTION
Fixes #30

## Summary

The edit button on agent cards was not showing the modal dialog when clicked. Investigation revealed that the `editAgent()` function was referencing an undefined variable `SPACE_DATA` instead of the correct global variable `cachedBoardData`.

## Root Cause

In `internal/coordinator/static/mission-control.html`, the `editAgent()` function (lines 1097-1150) attempted to access agent data from `SPACE_DATA.agents`, but `SPACE_DATA` is not defined anywhere in the codebase.

The correct variable is `cachedBoardData`, which is:
- Declared as a global variable at line 495
- Populated by `renderBoard()` at line 1323
- Used throughout the codebase for accessing current board state

## Changes

Replaced 3 occurrences of `SPACE_DATA` with `cachedBoardData` in the `editAgent()` function:
- Line 1104: `if (cachedBoardData && cachedBoardData.agents)`
- Line 1105: `for (var name in cachedBoardData.agents)`  
- Line 1107: `agent = cachedBoardData.agents[name]`

## Testing

- All 80 tests pass with race detection (`make test`)
- Manual verification: Edit button now correctly displays the modal with pre-filled agent data

## Request

@Reviewer: Please review this fix for Issue #30. The change is minimal and focused - replacing an undefined variable reference with the correct global variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)