### PR TITLE
fix: move contracts section beneath agents in UI (Issue #34)

### DIFF
--- a/internal/coordinator/static/mission-control.html
+++ b/internal/coordinator/static/mission-control.html
@@ -1332,8 +1332,8 @@ function renderBoard(data, sessionData, eventLog, interruptMetrics, interruptLog
   renderPanelOverview(data, sorted, sessionData);
   if (!inboxLocked) renderPanelInbox(data, sorted);
   renderPanelInterrupts(interruptMetrics, interruptLog);
-  renderPanelContracts(data);
   renderPanelAgents(data, sorted, sessionData);
+  renderPanelContracts(data);
 
   var dot = '<span class="header-dot" style="background:var(--green)"></span>';
   document.getElementById('agent-count').innerHTML = dot + names.length + ' agents';


### PR DESCRIPTION
Fixes #34

## Summary

Moved the contracts section to appear **beneath** the agents section in the UI, as requested. Previously contracts appeared above agents.

## Changes

Updated the render order in the `renderBoard()` function (`mission-control.html`):

**Before:**
```javascript
renderPanelInterrupts(interruptMetrics, interruptLog);
renderPanelContracts(data);              // Contracts rendered FIRST
renderPanelAgents(data, sorted, sessionData);  // Agents rendered SECOND
```

**After:**
```javascript
renderPanelInterrupts(interruptMetrics, interruptLog);
renderPanelAgents(data, sorted, sessionData);  // Agents rendered FIRST
renderPanelContracts(data);              // Contracts rendered SECOND (beneath agents)
```

## Visual Result

The UI now displays panels in this order:
1. Project Overview
2. Inbox
3. Interrupts
4. **Agents** ← Now appears first
5. **Contracts** ← Now appears beneath agents

## Testing

- ✅ All 80 tests pass with race detection (`make test`)
- ✅ Simple 1-line change with no functional impact
- ✅ Only affects visual order of UI panels

## Request

@Reviewer: Please review this UI ordering fix for Issue #34. The change is minimal - just swapping two lines to reorder the panel rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)